### PR TITLE
Convert case to one-liner

### DIFF
--- a/jwst/build.sh
+++ b/jwst/build.sh
@@ -1,12 +1,2 @@
-case `uname` in
-    Darwin)
-    export LDFLAGS="${LDFLAGS} -headerpad_max_install_names"
-    ;;
-    Linux)
-    export CFLAGS="${CFLAGS} -Wl,-headerpad_max_install_names"
-    ;;
-    *)
-    ;;
-esac
-
+export CFLAGS="${CFLAGS} -Wl,-headerpad_max_install_names"
 $PYTHON setup.py install


### PR DESCRIPTION
Addresses headerpadding on both Darwin and Linux.