### PR TITLE
Add readline (workaround)

### DIFF
--- a/readline/build.sh
+++ b/readline/build.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+if [ `uname -m` == ppc64le ]; then
+    B="--build=ppc64le-linux"
+fi
+
+./configure $B --prefix=$PREFIX
+make
+make install
+
+rm -rf $PREFIX/share/man
+rm -rf $PREFIX/share/readline

--- a/readline/meta.yaml
+++ b/readline/meta.yaml
@@ -1,0 +1,29 @@
+package:
+  name: readline
+  version: 6.2
+
+source:
+  fn: readline-6.2.tar.gz
+  url: http://ftp.gnu.org/gnu/readline/readline-6.2.tar.gz
+  md5: 67948acb2ca081f23359d0256e9a271c
+  patches:
+    - tpn.patch
+    - ncurses.patch
+
+build:
+  number: 3
+
+about:
+  home: http://cnswww.cns.cwru.edu/php/chet/readline/rltop.html
+  license: GPL3
+  license_file: COPYING
+  summary: Line-editing for programs with a command-line interface
+  description: |
+    The GNU Readline library provides a set of functions for use by
+    applications that allow users to edit command lines as they are typed in.
+    Both Emacs and vi editing modes are available. The Readline library
+    includes additional functions to maintain a list of previously-entered
+    command lines, to recall and perhaps reedit those lines, and perform
+    csh-like history expansion on previous commands.
+  doc_url: http://cnswww.cns.cwru.edu/php/chet/readline/rltop.html#Documentation
+

--- a/readline/ncurses.patch
+++ b/readline/ncurses.patch
@@ -1,0 +1,12 @@
+diff --git support/shobj-conf support/shobj-conf
+index d47bd80..fc8da1e 100644
+--- support/shobj-conf
++++ support/shobj-conf
+@@ -114,6 +114,7 @@ linux*-*|gnu*-*|k*bsd*-gnu-*|freebsd*-gentoo)
+ 	SHOBJ_LD='${CC}'
+ 	SHOBJ_LDFLAGS='-shared -Wl,-soname,$@'
+ 
++	SHLIB_LIBS='-lncurses'
+ 	SHLIB_XLDFLAGS='-Wl,-rpath,$(libdir) -Wl,-soname,`basename $@ $(SHLIB_MINOR)`'
+ 	SHLIB_LIBVERSION='$(SHLIB_LIBSUFF).$(SHLIB_MAJOR)$(SHLIB_MINOR)'
+ 	;;

--- a/readline/tpn.patch
+++ b/readline/tpn.patch
@@ -1,0 +1,152 @@
+diff --git callback.c callback.c
+index 4ee6361..6c79d41 100644
+--- callback.c
++++ callback.c
+@@ -148,6 +148,9 @@ rl_callback_read_char ()
+ 	  eof = _rl_vi_domove_callback (_rl_vimvcxt);
+ 	  /* Should handle everything, including cleanup, numeric arguments,
+ 	     and turning off RL_STATE_VIMOTION */
++          if (RL_ISSTATE (RL_STATE_NUMERICARG) == 0)
++            _rl_internal_char_cleanup ();
++
+ 	  return;
+ 	}
+ #endif
+diff --git input.c input.c
+index 7c74c99..99593a3 100644
+--- input.c
++++ input.c
+@@ -409,7 +409,7 @@ rl_clear_pending_input ()
+ int
+ rl_read_key ()
+ {
+-  int c;
++  int c, r;
+ 
+   rl_key_sequence_length++;
+ 
+@@ -429,11 +429,17 @@ rl_read_key ()
+ 	{
+ 	  while (rl_event_hook)
+ 	    {
+-	      if (rl_gather_tyi () < 0)	/* XXX - EIO */
++              if (rl_get_char (&c) != 0)
++                break;
++
++	      if ((r = rl_gather_tyi ()) < 0)	/* XXX - EIO */
+ 		{
+ 		  rl_done = 1;
+ 		  return ('\n');
+ 		}
++              else if (r == 1)		/* read something */
++                continue;
++
+ 	      RL_CHECK_SIGNALS ();
+ 	      if (rl_get_char (&c) != 0)
+ 		break;
+diff --git patchlevel patchlevel
+index fdf4740..e0ba09d 100644
+--- patchlevel
++++ patchlevel
+@@ -1,3 +1,3 @@
+ # Do not edit -- exists only for use by patch
+ 
+-1
++5
+diff --git support/shobj-conf support/shobj-conf
+index 5a63e80..d47bd80 100644
+--- support/shobj-conf
++++ support/shobj-conf
+@@ -157,7 +157,7 @@ freebsd[4-9]*|freebsdelf*|dragonfly*)
+ 	;;
+ 
+ # Darwin/MacOS X
+-darwin[89]*|darwin10*)
++darwin[89]*|darwin1[0123]*)
+ 	SHOBJ_STATUS=supported
+ 	SHLIB_STATUS=supported
+ 	
+@@ -186,7 +186,7 @@ darwin*|macosx*)
+ 	SHLIB_LIBSUFF='dylib'
+ 
+ 	case "${host_os}" in
+-	darwin[789]*|darwin10*)	SHOBJ_LDFLAGS=''
++	darwin[789]*|darwin1[0123]*)	SHOBJ_LDFLAGS=''
+ 			SHLIB_XLDFLAGS='-dynamiclib -arch_only `/usr/bin/arch` -install_name $(libdir)/$@ -current_version $(SHLIB_MAJOR)$(SHLIB_MINOR) -compatibility_version $(SHLIB_MAJOR) -v'
+ 			;;
+ 	*)		SHOBJ_LDFLAGS='-dynamic'
+diff --git vi_mode.c vi_mode.c
+index 41e1dbb..9a51b2b 100644
+--- vi_mode.c
++++ vi_mode.c
+@@ -1114,7 +1114,7 @@ rl_domove_read_callback (m)
+       rl_beg_of_line (1, c);
+       _rl_vi_last_motion = c;
+       RL_UNSETSTATE (RL_STATE_VIMOTION);
+-      return (0);
++      return (vidomove_dispatch (m));
+     }
+ #if defined (READLINE_CALLBACKS)
+   /* XXX - these need to handle rl_universal_argument bindings */
+@@ -1234,11 +1234,19 @@ rl_vi_delete_to (count, key)
+       _rl_vimvcxt->motion = '$';
+       r = rl_domove_motion_callback (_rl_vimvcxt);
+     }
+-  else if (vi_redoing)
++  else if (vi_redoing && _rl_vi_last_motion != 'd')   /* `dd' is special */
+     {
+       _rl_vimvcxt->motion = _rl_vi_last_motion;
+       r = rl_domove_motion_callback (_rl_vimvcxt);
+     }
++  else if (vi_redoing)                /* handle redoing `dd' here */
++    {
++      _rl_vimvcxt->motion = _rl_vi_last_motion;
++      rl_mark = rl_end;
++      rl_beg_of_line (1, key);
++      RL_UNSETSTATE (RL_STATE_VIMOTION);
++      r = vidomove_dispatch (_rl_vimvcxt);
++    }
+ #if defined (READLINE_CALLBACKS)
+   else if (RL_ISSTATE (RL_STATE_CALLBACK))
+     {
+@@ -1316,11 +1324,19 @@ rl_vi_change_to (count, key)
+       _rl_vimvcxt->motion = '$';
+       r = rl_domove_motion_callback (_rl_vimvcxt);
+     }
+-  else if (vi_redoing)
++  else if (vi_redoing && _rl_vi_last_motion != 'c')   /* `cc' is special */
+     {
+       _rl_vimvcxt->motion = _rl_vi_last_motion;
+       r = rl_domove_motion_callback (_rl_vimvcxt);
+     }
++  else if (vi_redoing)                /* handle redoing `cc' here */
++    {
++      _rl_vimvcxt->motion = _rl_vi_last_motion;
++      rl_mark = rl_end;
++      rl_beg_of_line (1, key);
++      RL_UNSETSTATE (RL_STATE_VIMOTION);
++      r = vidomove_dispatch (_rl_vimvcxt);
++    }
+ #if defined (READLINE_CALLBACKS)
+   else if (RL_ISSTATE (RL_STATE_CALLBACK))
+     {
+@@ -1377,6 +1393,19 @@ rl_vi_yank_to (count, key)
+       _rl_vimvcxt->motion = '$';
+       r = rl_domove_motion_callback (_rl_vimvcxt);
+     }
++  else if (vi_redoing && _rl_vi_last_motion != 'y')   /* `yy' is special */
++    {
++      _rl_vimvcxt->motion = _rl_vi_last_motion;
++      r = rl_domove_motion_callback (_rl_vimvcxt);
++    }
++  else if (vi_redoing)                        /* handle redoing `yy' here */
++    {
++      _rl_vimvcxt->motion = _rl_vi_last_motion;
++      rl_mark = rl_end;
++      rl_beg_of_line (1, key);
++      RL_UNSETSTATE (RL_STATE_VIMOTION);
++      r = vidomove_dispatch (_rl_vimvcxt);
++    }
+ #if defined (READLINE_CALLBACKS)
+   else if (RL_ISSTATE (RL_STATE_CALLBACK))
+     {


### PR DESCRIPTION
`readline` indev will not be updated to match further developments from Continuum. However, this critical revision fixes the broken ncurses linkage under Linux.

