### PR TITLE
Rebuild hstcal

### DIFF
--- a/hstcal/meta.yaml
+++ b/hstcal/meta.yaml
@@ -2,7 +2,7 @@
 {% set version = environ.get("GIT_DESCRIBE_TAG", "0.0.0")
     +".dev"
     +environ.get("GIT_DESCRIBE_NUMBER", "0") %}
-{% set number = '2' %}
+{% set number = '3' %}
 
 about:
     home: https://github.com/spacetelescope/{{ name }}


### PR DESCRIPTION
MD5 mismatch on OSX. Trying to correct for it.