### PR TITLE
astropy: add pytest as build dependency

### DIFF
--- a/astropy/meta.yaml
+++ b/astropy/meta.yaml
@@ -18,6 +18,7 @@ requirements:
     build:
     - cython
     - jinja2
+    - pytest
     - setuptools
     - numpy x.x
     - python x.x


### PR DESCRIPTION
Fixes:
```python
RuntimeError: Setuptools downloading is disabled in conda build. Be sure to add all dependencies in the meta.yaml  url=https://pypi.python.org/simple/pytest/r
```