### PR TITLE
Add pytest as runtime dependency

### DIFF
--- a/astropy/meta.yaml
+++ b/astropy/meta.yaml
@@ -33,6 +33,7 @@ requirements:
     - matplotlib
     - mpmath
     - pandas
+    - pytest
     - pytz
     - pyyaml
     - scikit-image


### PR DESCRIPTION
Apparently astropy's scripts require `pytest` to exist.
Seems like a bug to me.