### PR TITLE
Remove deprecated samp_hub smoketest

### DIFF
--- a/astropy/meta.yaml
+++ b/astropy/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = 'astropy' %}
 {% set version = '2.0.dev' + environ.get("GIT_DESCRIBE_NUMBER", "0") %}
-{% set number = '1' %}
+{% set number = '0' %}
 
 about:
     home: https://github.com/astropy/{{ name }}
@@ -50,7 +50,6 @@ test:
     - fitscheck --help
     - fitsdiff --help
     - fitsinfo --help
-    - samp_hub --help
     - volint --help
     - wcslint --help
     imports:


### PR DESCRIPTION
```python
+ samp_hub --help
WARNING: AstropyDeprecationWarning: The astropy.samp module has now been moved to astropy.samp [astropy.vo.samp]
Traceback (most recent call last):
  File "/Users/shared/iraf_conda/bldtmp/p3wX/p/conda-bld/astropy_1498636857655/_t_env/bin/samp_hub", line 11, in <module>
    load_entry_point('astropy==3.0.dev19488', 'console_scripts', 'samp_hub')()
  File "/Users/shared/iraf_conda/bldtmp/p3wX/p/conda-bld/astropy_1498636857655/_t_env/lib/python3.5/site-packages/setuptools-27.2.0-py3.5.egg/pkg_resources/__init__.py", line 565, in load_entry_point
  File "/Users/shared/iraf_conda/bldtmp/p3wX/p/conda-bld/astropy_1498636857655/_t_env/lib/python3.5/site-packages/setuptools-27.2.0-py3.5.egg/pkg_resources/__init__.py", line 2598, in load_entry_point
  File "/Users/shared/iraf_conda/bldtmp/p3wX/p/conda-bld/astropy_1498636857655/_t_env/lib/python3.5/site-packages/setuptools-27.2.0-py3.5.egg/pkg_resources/__init__.py", line 2258, in load
  File "/Users/shared/iraf_conda/bldtmp/p3wX/p/conda-bld/astropy_1498636857655/_t_env/lib/python3.5/site-packages/setuptools-27.2.0-py3.5.egg/pkg_resources/__init__.py", line 2264, in resolve
ImportError: No module named 'astropy.vo.samp.hub_script'
```