### PR TITLE
Add git commit hash to build string of recipes that use git.

### DIFF
--- a/acstools/meta.yaml
+++ b/acstools/meta.yaml
@@ -11,6 +11,7 @@ about:
 
 build:
     number: {{ number }}
+    string: {{ GIT_DESCRIBE_HASH }}__{{ number }}
 
 package:
     name: {{ name }}

--- a/aprio/meta.yaml
+++ b/aprio/meta.yaml
@@ -11,6 +11,7 @@ about:
 
 build:
     number: {{ number }}
+    string: {{ GIT_DESCRIBE_HASH }}__{{ number }}
 
 package:
     name: {{ name }}

--- a/asdf-standard/meta.yaml
+++ b/asdf-standard/meta.yaml
@@ -11,6 +11,7 @@ about:
 
 build:
     number: {{ number }}
+    string: {{ GIT_DESCRIBE_HASH }}__{{ number }}
 
 package:
     name: {{ name }}

--- a/asdf/meta.yaml
+++ b/asdf/meta.yaml
@@ -11,6 +11,7 @@ about:
 
 build:
     number: {{ number }}
+    string: {{ GIT_DESCRIBE_HASH }}__{{ number }}
 
 package:
     name: {{ name }}

--- a/astroimtools/meta.yaml
+++ b/astroimtools/meta.yaml
@@ -11,6 +11,7 @@ about:
 
 build:
     number: {{ number }}
+    string: {{ GIT_DESCRIBE_HASH }}__{{ number }}
 
 package:
     name: {{ name }}

--- a/astrolib.coords/meta.yaml
+++ b/astrolib.coords/meta.yaml
@@ -11,6 +11,7 @@ about:
 
 build:
     number: {{ number }}
+    string: {{ GIT_DESCRIBE_HASH }}__{{ number }}
 
 package:
     name: {{ name }}

--- a/astropy/meta.yaml
+++ b/astropy/meta.yaml
@@ -9,6 +9,7 @@ about:
 
 build:
     number: {{ number }}
+    string: {{ GIT_DESCRIBE_HASH }}__{{ number }}
 
 package:
     name: {{ name }}

--- a/asv/meta.yaml
+++ b/asv/meta.yaml
@@ -11,6 +11,7 @@ about:
 
 build:
     number: {{ number }}
+    string: {{ GIT_DESCRIBE_HASH }}__{{ number }}
 
 package:
     name: {{ name }}

--- a/calcos/meta.yaml
+++ b/calcos/meta.yaml
@@ -10,6 +10,7 @@ about:
 
 build:
     number: {{ number }}
+    string: {{ GIT_DESCRIBE_HASH }}__{{ number }}
 
 package:
     name: {{ name }}

--- a/costools/meta.yaml
+++ b/costools/meta.yaml
@@ -11,6 +11,7 @@ about:
 
 build:
     number: {{ number }}
+    string: {{ GIT_DESCRIBE_HASH }}__{{ number }}
 
 package:
     name: {{ name }}

--- a/crds/meta.yaml
+++ b/crds/meta.yaml
@@ -13,6 +13,7 @@ about:
 
 build:
     number: {{ number }}
+    string: {{ GIT_DESCRIBE_HASH }}__{{ number }}
     preserve_egg_dir: 'no'
 
 package:

--- a/cube-tools/meta.yaml
+++ b/cube-tools/meta.yaml
@@ -11,6 +11,7 @@ about:
 
 build:
     number: {{ number }}
+    string: {{ GIT_DESCRIBE_HASH }}__{{ number }}
 
 package:
     name: {{ name }}

--- a/d2to1/meta.yaml
+++ b/d2to1/meta.yaml
@@ -11,6 +11,7 @@ about:
 
 build:
     number: {{ number }}
+    string: {{ GIT_DESCRIBE_HASH }}__{{ number }}
 
 package:
     name: {{ name }}

--- a/drizzle/meta.yaml
+++ b/drizzle/meta.yaml
@@ -15,6 +15,7 @@ package:
 
 build:
     number: {{ number }}
+    string: {{ GIT_DESCRIBE_HASH }}__{{ number }}
 
 requirements:
     build:

--- a/drizzlepac/meta.yaml
+++ b/drizzlepac/meta.yaml
@@ -11,6 +11,7 @@ about:
 
 build:
     number: {{ number }}
+    string: {{ GIT_DESCRIBE_HASH }}__{{ number }}
 
 package:
     name: {{ name }}

--- a/ext_shmht/meta.yaml
+++ b/ext_shmht/meta.yaml
@@ -11,6 +11,7 @@ about:
 
 build:
     number: {{ number }}
+    string: {{ GIT_DESCRIBE_HASH }}__{{ number }}
 
 package:
     name: {{ name }}

--- a/fitsblender/meta.yaml
+++ b/fitsblender/meta.yaml
@@ -11,6 +11,7 @@ about:
 
 build:
     number: {{ number }}
+    string: {{ GIT_DESCRIBE_HASH }}__{{ number }}
 
 package:
     name: {{ name }}

--- a/gwcs/meta.yaml
+++ b/gwcs/meta.yaml
@@ -11,6 +11,7 @@ about:
 
 build:
     number: {{ number }}
+    string: {{ GIT_DESCRIBE_HASH }}__{{ number }}
 
 package:
     name: {{ name }}

--- a/hstcal/meta.yaml
+++ b/hstcal/meta.yaml
@@ -11,6 +11,7 @@ about:
 
 build:
     number: {{ number }}
+    string: {{ GIT_DESCRIBE_HASH }}__{{ number }}
 
 package:
     name: {{ name }}

--- a/htc_utils/meta.yaml
+++ b/htc_utils/meta.yaml
@@ -11,6 +11,7 @@ about:
 
 build:
     number: {{ number }}
+    string: {{ GIT_DESCRIBE_HASH }}__{{ number }}
 
 package:
     name: {{ name }}

--- a/imexam/meta.yaml
+++ b/imexam/meta.yaml
@@ -11,6 +11,7 @@ about:
 
 build:
     number: {{ number }}
+    string: {{ GIT_DESCRIBE_HASH }}__{{ number }}
 
 package:
     name: {{ name }}

--- a/imgeom/meta.yaml
+++ b/imgeom/meta.yaml
@@ -15,6 +15,7 @@ package:
 
 build:
     number: {{ number }}
+    string: {{ GIT_DESCRIBE_HASH }}__{{ number }}
 
 source:
     git_url: https://github.com/spacetelescope/{{ name }}.git

--- a/jplephem/meta.yaml
+++ b/jplephem/meta.yaml
@@ -11,6 +11,7 @@ about:
 
 build:
     number: {{ number }}
+    string: {{ GIT_DESCRIBE_HASH }}__{{ number }}
 
 package:
     name: {{ name }}

--- a/jwst/meta.yaml
+++ b/jwst/meta.yaml
@@ -11,6 +11,7 @@ about:
 
 build:
     number: {{ number }}
+    string: {{ GIT_DESCRIBE_HASH }}__{{ number }}
     preserve_egg_dir: 'True'
 
 package:

--- a/jwst_gtvt/meta.yaml
+++ b/jwst_gtvt/meta.yaml
@@ -13,6 +13,7 @@ about:
 
 build:
     number: {{ number }}
+    string: {{ GIT_DESCRIBE_HASH }}__{{ number }}
 
 package:
     name: {{ name }}

--- a/jwst_lib/meta.yaml
+++ b/jwst_lib/meta.yaml
@@ -11,6 +11,7 @@ about:
 
 build:
     number: {{ number }}
+    string: {{ GIT_DESCRIBE_HASH }}__{{ number }}
     preserve_egg_dir: 'True'
 
 package:

--- a/jwst_pipeline/meta.yaml
+++ b/jwst_pipeline/meta.yaml
@@ -11,6 +11,7 @@ about:
 
 build:
     number: {{ number }}
+    string: {{ GIT_DESCRIBE_HASH }}__{{ number }}
     preserve_egg_dir: 'True'
 
 package:

--- a/jwst_tools/meta.yaml
+++ b/jwst_tools/meta.yaml
@@ -11,6 +11,7 @@ about:
 
 build:
     number: {{ number }}
+    string: {{ GIT_DESCRIBE_HASH }}__{{ number }}
     preserve_egg_dir: 'True'
 
 package:

--- a/jwxml/meta.yaml
+++ b/jwxml/meta.yaml
@@ -12,6 +12,7 @@ about:
 
 build:
     number: {{ number }}
+    string: {{ GIT_DESCRIBE_HASH }}__{{ number }}
 
 package:
     name: {{ name }}

--- a/nictools/meta.yaml
+++ b/nictools/meta.yaml
@@ -10,6 +10,7 @@ about:
 
 build:
     number: {{ number }}
+    string: {{ GIT_DESCRIBE_HASH }}__{{ number }}
 
 package:
     name: {{ name }}

--- a/opuscoords/meta.yaml
+++ b/opuscoords/meta.yaml
@@ -11,6 +11,7 @@ about:
 
 build:
     number: {{ number }}
+    string: {{ GIT_DESCRIBE_HASH }}__{{ number }}
 
 package:
     name: {{ name }}

--- a/pandeia_data/meta.yaml
+++ b/pandeia_data/meta.yaml
@@ -11,6 +11,7 @@ about:
 
 build:
     number: {{ number }}
+    string: {{ GIT_DESCRIBE_HASH }}__{{ number }}
     preserve_egg_dir: 'yes'
 
 package:

--- a/pandokia/meta.yaml
+++ b/pandokia/meta.yaml
@@ -11,6 +11,7 @@ about:
 
 build:
     number: {{ number }}
+    string: {{ GIT_DESCRIBE_HASH }}__{{ number }}
 
 package:
     name: {{ name }}

--- a/photutils/meta.yaml
+++ b/photutils/meta.yaml
@@ -11,6 +11,7 @@ about:
 
 build:
     number: {{ number }}
+    string: {{ GIT_DESCRIBE_HASH }}__{{ number }}
 
 package:
     name: {{ name }}

--- a/poppy/meta.yaml
+++ b/poppy/meta.yaml
@@ -11,6 +11,7 @@ about:
 
 build:
     number: {{ number }}
+    string: {{ GIT_DESCRIBE_HASH }}__{{ number }}
 
 package:
     name: {{ name }}

--- a/purge_path/meta.yaml
+++ b/purge_path/meta.yaml
@@ -11,6 +11,7 @@ about:
 
 build:
     number: {{ number }}
+    string: {{ GIT_DESCRIBE_HASH }}__{{ number }}
 
 package:
     name: {{ name }}

--- a/pyds9/meta.yaml
+++ b/pyds9/meta.yaml
@@ -11,6 +11,7 @@ about:
 
 build:
     number: {{ number }}
+    string: {{ GIT_DESCRIBE_HASH }}__{{ number }}
 
 package:
     name: {{ name }}

--- a/pyraf/meta.yaml
+++ b/pyraf/meta.yaml
@@ -11,6 +11,7 @@ about:
 
 build:
     number: {{ number }}
+    string: {{ GIT_DESCRIBE_HASH }}__{{ number }}
 
 package:
     name: {{ name }}

--- a/pyregion/meta.yaml
+++ b/pyregion/meta.yaml
@@ -11,6 +11,7 @@ about:
 
 build:
     number: {{ number }}
+    string: {{ GIT_DESCRIBE_HASH }}__{{ number }}
 
 package:
     name: {{ name }}

--- a/pysynphot/meta.yaml
+++ b/pysynphot/meta.yaml
@@ -11,6 +11,7 @@ about:
 
 build:
     number: {{ number }}
+    string: {{ GIT_DESCRIBE_HASH }}__{{ number }}
     preserve_egg_dir: 'yes'
 
 package:

--- a/pywcs/meta.yaml
+++ b/pywcs/meta.yaml
@@ -11,6 +11,7 @@ about:
 
 build:
     number: {{ number }}
+    string: {{ GIT_DESCRIBE_HASH }}__{{ number }}
 
 package:
     name: {{ name }}

--- a/reftools/meta.yaml
+++ b/reftools/meta.yaml
@@ -11,6 +11,7 @@ about:
 
 build:
     number: {{ number }}
+    string: {{ GIT_DESCRIBE_HASH }}__{{ number }}
     preserve_egg_dir: 'yes'
 
 package:

--- a/relic/meta.yaml
+++ b/relic/meta.yaml
@@ -11,6 +11,7 @@ about:
 
 build:
     number: {{ number }}
+    string: {{ GIT_DESCRIBE_HASH }}__{{ number }}
 
 package:
     name: {{ name }}

--- a/specutils/meta.yaml
+++ b/specutils/meta.yaml
@@ -14,6 +14,7 @@ package:
 
 build:
     number: {{ number }}
+    string: {{ GIT_DESCRIBE_HASH }}__{{ number }}
 
 source:
     git_tag: {{ tag }}

--- a/specview/meta.yaml
+++ b/specview/meta.yaml
@@ -11,6 +11,7 @@ about:
 
 build:
     number: {{ number }}
+    string: {{ GIT_DESCRIBE_HASH }}__{{ number }}
 
 package:
     name: {{ name }}

--- a/spherical-geometry/meta.yaml
+++ b/spherical-geometry/meta.yaml
@@ -12,6 +12,7 @@ about:
 
 build:
     number: {{ number }}
+    string: {{ GIT_DESCRIBE_HASH }}__{{ number }}
 
 package:
     name: {{ name }}

--- a/stginga/meta.yaml
+++ b/stginga/meta.yaml
@@ -11,6 +11,7 @@ about:
 
 build:
     number: {{ number }}
+    string: {{ GIT_DESCRIBE_HASH }}__{{ number }}
 
 package:
     name: {{ name }}

--- a/stistools/meta.yaml
+++ b/stistools/meta.yaml
@@ -11,6 +11,7 @@ about:
 
 build:
     number: {{ number }}
+    string: {{ GIT_DESCRIBE_HASH }}__{{ number }}
 
 package:
     name: {{ name }}

--- a/stsci.convolve/meta.yaml
+++ b/stsci.convolve/meta.yaml
@@ -11,6 +11,7 @@ about:
 
 build:
     number: {{ number }}
+    string: {{ GIT_DESCRIBE_HASH }}__{{ number }}
     preserve_egg_dir: 'yes'
 
 package:

--- a/stsci.distutils/meta.yaml
+++ b/stsci.distutils/meta.yaml
@@ -11,6 +11,7 @@ about:
 
 build:
     number: {{ number }}
+    string: {{ GIT_DESCRIBE_HASH }}__{{ number }}
 
 package:
     name: {{ name }}

--- a/stsci.image/meta.yaml
+++ b/stsci.image/meta.yaml
@@ -11,6 +11,7 @@ about:
 
 build:
     number: {{ number }}
+    string: {{ GIT_DESCRIBE_HASH }}__{{ number }}
     preserve_egg_dir: 'yes'
 
 package:

--- a/stsci.imagemanip/meta.yaml
+++ b/stsci.imagemanip/meta.yaml
@@ -10,6 +10,7 @@ about:
     summary: stsci.imagemanip
 build:
     number: {{ number }}
+    string: {{ GIT_DESCRIBE_HASH }}__{{ number }}
     preserve_egg_dir: 'yes'
 
 package:

--- a/stsci.imagestats/meta.yaml
+++ b/stsci.imagestats/meta.yaml
@@ -11,6 +11,7 @@ about:
 
 build:
     number: {{ number }}
+    string: {{ GIT_DESCRIBE_HASH }}__{{ number }}
     preserve_egg_dir: 'yes'
 
 package:

--- a/stsci.ndimage/meta.yaml
+++ b/stsci.ndimage/meta.yaml
@@ -11,6 +11,7 @@ about:
 
 build:
     number: {{ number }}
+    string: {{ GIT_DESCRIBE_HASH }}__{{ number }}
     preserve_egg_dir: 'yes'
 
 package:

--- a/stsci.numdisplay/meta.yaml
+++ b/stsci.numdisplay/meta.yaml
@@ -11,6 +11,7 @@ about:
 
 build:
     number: {{ number }}
+    string: {{ GIT_DESCRIBE_HASH }}__{{ number }}
     preserve_egg_dir: 'yes'
 
 package:

--- a/stsci.skypac/meta.yaml
+++ b/stsci.skypac/meta.yaml
@@ -11,6 +11,7 @@ about:
 
 build:
     number: {{ number }}
+    string: {{ GIT_DESCRIBE_HASH }}__{{ number }}
     preserve_egg_dir: 'yes'
 
 package:

--- a/stsci.sphere/meta.yaml
+++ b/stsci.sphere/meta.yaml
@@ -11,6 +11,7 @@ about:
 
 build:
     number: {{ number }}
+    string: {{ GIT_DESCRIBE_HASH }}__{{ number }}
     preserve_egg_dir: 'yes'
 
 package:

--- a/stsci.sphinxext/meta.yaml
+++ b/stsci.sphinxext/meta.yaml
@@ -11,6 +11,7 @@ about:
 
 build:
     number: {{ number }}
+    string: {{ GIT_DESCRIBE_HASH }}__{{ number }}
     preserve_egg_dir: 'yes'
 
 package:

--- a/stsci.stimage/meta.yaml
+++ b/stsci.stimage/meta.yaml
@@ -11,6 +11,7 @@ about:
 
 build:
     number: {{ number }}
+    string: {{ GIT_DESCRIBE_HASH }}__{{ number }}
     preserve_egg_dir: 'yes'
 
 package:

--- a/stsci.tools/meta.yaml
+++ b/stsci.tools/meta.yaml
@@ -11,6 +11,7 @@ about:
 
 build:
     number: {{ number }}
+    string: {{ GIT_DESCRIBE_HASH }}__{{ number }}
     preserve_egg_dir: 'yes'
 
 package:

--- a/stwcs/meta.yaml
+++ b/stwcs/meta.yaml
@@ -11,6 +11,7 @@ about:
 
 build:
     number: {{ number }}
+    string: {{ GIT_DESCRIBE_HASH }}__{{ number }}
 
 package:
     name: {{ name }}

--- a/verhawk/meta.yaml
+++ b/verhawk/meta.yaml
@@ -11,6 +11,7 @@ about:
 
 build:
     number: {{ number }}
+    string: {{ GIT_DESCRIBE_HASH }}__{{ number }}
 
 package:
     name: {{ name }}

--- a/webbpsf/meta.yaml
+++ b/webbpsf/meta.yaml
@@ -16,6 +16,7 @@ about:
 
 build:
     number: {{ number }}
+    string: {{ GIT_DESCRIBE_HASH }}__{{ number }}
     preserve_egg_dir: 'True'
 
 package:

--- a/wfc3tools/meta.yaml
+++ b/wfc3tools/meta.yaml
@@ -11,6 +11,7 @@ about:
 
 build:
     number: {{ number }}
+    string: {{ GIT_DESCRIBE_HASH }}__{{ number }}
 
 package:
     name: {{ name }}

--- a/wfpc2tools/meta.yaml
+++ b/wfpc2tools/meta.yaml
@@ -11,6 +11,7 @@ about:
 
 build:
     number: {{ number }}
+    string: {{ GIT_DESCRIBE_HASH }}__{{ number }}
 
 package:
     name: {{ name }}

--- a/xpa/meta.yaml
+++ b/xpa/meta.yaml
@@ -10,6 +10,7 @@ about:
     summary: Provides seamless communication between many kinds of Unix programs
 build:
     number: {{ number }}
+    string: {{ GIT_DESCRIBE_HASH }}__{{ number }}
 package:
     name: {{ name }}
     version: {{ version }}


### PR DESCRIPTION
The `py##` string is no longer present in generated package file names. Previously it was automatically made part of the default build string for packages that have a dependency on python but the default build string is not accessible for extension, so the build string is now defined explicitly in order to allow the inclusion of the git commit hash. This arrangement avoids the need for different build string definitions between packages that require python and those that don't.

The build string has a double underscore (`__`) because of conda-build 3.x's behavior of inserting the new **recipe hash** immediately before the last `_` seen in the build string.

Thus, for packages built under conda-build 2.x, tarball names look like:
`acstools-2.0.9.dev0-g39122b2__1.tar.bz2`

For packages built under conda-build 3.x:
`acstools-2.0.9.dev0-g39122b2_h51057e5_2.tar.bz2`

The `g<7-chars>` string is the git commit hash for the source used to create the package.
The `h<7-chars>` string is the automatically provided conda-build 3.x recipe hash.