### PR TITLE
[asdf] Add missing semantic_version dependency

### DIFF
--- a/asdf/meta.yaml
+++ b/asdf/meta.yaml
@@ -22,6 +22,7 @@ requirements:
     - pyyaml
     - jsonschema
     - pytest
+    - semantic_version >=2.6.0
     - six
     - setuptools
     - numpy
@@ -32,6 +33,7 @@ requirements:
     - pyyaml
     - jsonschema
     - pytest
+    - semantic_version >=2.6.0
     - six
     - setuptools
     - numpy


### PR DESCRIPTION
Fixes recent build failure:
```python
RuntimeError: Setuptools downloading is disabled in conda build. Be sure to add all dependencies in the meta.yaml  url=https://pypi.python.org/simple/semantic_version/r
```
CC @nden @drdavella