### PR TITLE
Initial commit of pymssql

### DIFF
--- a/pymssql/0001-Drop-usage-of-DBVERSION_80-symbol-d90c9b.patch
+++ b/pymssql/0001-Drop-usage-of-DBVERSION_80-symbol-d90c9b.patch
@@ -1,0 +1,43 @@
+From d90c9b85eea83bdebee0300c2ff6fa3c9d0b1508 Mon Sep 17 00:00:00 2001
+From: Ramiro Morales <cramm0@gmail.com>
+Date: Wed, 22 Jun 2016 19:58:03 -0300
+Subject: [PATCH] Drop usage of `DBVERSION_80` symbol.
+
+It was deprecated and was finally removed in FreeTDS 1.0.
+
+Fixes #432.
+---
+ src/_mssql.pyx   | 4 +---
+ src/sqlfront.pxd | 1 -
+ 2 files changed, 1 insertion(+), 4 deletions(-)
+
+diff --git a/src/_mssql.pyx b/src/_mssql.pyx
+index 463a6e0..6f95032 100644
+--- a/_mssql.pyx
++++ b/_mssql.pyx
+@@ -1708,12 +1708,10 @@ cdef int _tds_ver_str_to_constant(verstr) except -1:
+         return DBVERSION_42
+     if verstr == u'7.0':
+         return DBVERSION_70
+-    if verstr == u'7.1':
++    if verstr in (u'7.1', u'8.0'):
+         return DBVERSION_71
+     if verstr == u'7.2':
+         return DBVERSION_72
+-    if verstr == u'8.0':
+-        return DBVERSION_80
+     raise MSSQLException('unrecognized tds version: %s' % verstr)
+ 
+ #######################
+diff --git a/src/sqlfront.pxd b/src/sqlfront.pxd
+index d0ef691..91ab005 100644
+--- a/sqlfront.pxd
++++ b/sqlfront.pxd
+@@ -106,7 +106,6 @@ cdef extern from "sqlfront.h":
+     int DBVERSION_70
+     int DBVERSION_71
+     int DBVERSION_72
+-    int DBVERSION_80
+ 
+     ## Type Constants ##
+     cdef enum:

--- a/pymssql/0002-Change-setup_requires-setuptools_git-to-setuptools.patch
+++ b/pymssql/0002-Change-setup_requires-setuptools_git-to-setuptools.patch
@@ -1,0 +1,11 @@
+--- pymssql-2.1.3/setup.py.orig	2016-08-31 23:10:09.252141276 +0100
++++ pymssql-2.1.3/setup.py	2016-08-31 23:10:16.132353458 +0100
+@@ -472,7 +472,7 @@
+       "Operating System :: Unix",
+     ],
+     zip_safe = False,
+-    setup_requires=['setuptools_git'],
++    setup_requires=['setuptools'],
+     tests_require=['pytest', 'unittest2'],
+     ext_modules = ext_modules(),
+ 

--- a/pymssql/0003-Use-libsybdb-not-db-lib-since-I-renamed-it.patch
+++ b/pymssql/0003-Use-libsybdb-not-db-lib-since-I-renamed-it.patch
@@ -1,0 +1,11 @@
+--- pymssql-2.1.3/setup.py.orig	2016-09-03 13:39:04.565627400 +0100
++++ pymssql-2.1.3/setup.py	2016-09-04 12:20:09.687056500 +0100
+@@ -290,7 +290,7 @@
+                     freetds_dir = 'vs2008'
+                 if LINK_FREETDS_STATICALLY:
+                     libraries = [
+-                        'db-lib', 'tds', 'replacements',
++                        'libsybdb', 'tds', 'replacements',
+                         'iconv',
+                         'ws2_32', 'wsock32', 'kernel32', 'shell32',
+                     ]

--- a/pymssql/0004-Win32-link-to-openssl.patch
+++ b/pymssql/0004-Win32-link-to-openssl.patch
@@ -1,0 +1,31 @@
+--- pymssql-2.1.3/setup.py.orig	2016-09-04 19:07:43.033279900 +0100
++++ pymssql-2.1.3/setup.py	2016-09-04 19:16:31.135243100 +0100
+@@ -59,7 +59,7 @@
+ from setuptools.command.test import test as TestCommand
+ 
+ LINK_FREETDS_STATICALLY = True
+-LINK_OPENSSL = False
++LINK_OPENSSL = True
+ 
+ ROOT = osp.abspath(osp.dirname(__file__))
+ 
+@@ -296,8 +296,8 @@
+                     ]
+                     if LINK_OPENSSL:
+                         libraries.extend([
+-                            'libeay{}MD'.format(BITNESS),
+-                            'ssleay{}MD'.format(BITNESS)
++                            'libeay32',
++                            'ssleay32'
+                         ])
+                 else:
+                     libraries = [
+@@ -305,7 +305,7 @@
+                         'ws2_32', 'wsock32', 'kernel32', 'shell32',
+                     ]
+                     if LINK_OPENSSL:
+-                        libraries.extend(['libeay32MD', 'ssleay32MD'])
++                        libraries.extend(['libeay32', 'ssleay32'])
+ 
+             FREETDS = fpath('freetds', '{0}_{1}'.format(freetds_dir, BITNESS))
+             suffix = '' if BITNESS == 32 else '64'

--- a/pymssql/bld.bat
+++ b/pymssql/bld.bat
@@ -1,0 +1,11 @@
+del _mssql.c
+"%PYTHON%" setup.py build_ext -I "%PREFIX%"\include -L "%PREFIX%"\lib
+if errorlevel 1 exit 1
+"%PYTHON%" setup.py install --single-version-externally-managed --record=record.txt
+if errorlevel 1 exit 1
+
+:: Add more build steps here, if they are necessary.
+
+:: See
+:: http://docs.continuum.io/conda/build.html
+:: for a list of environment variables that are set during the build process.

--- a/pymssql/build.sh
+++ b/pymssql/build.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Force regeneration of this since we patched out
+# the usage of `DBVERSION_80` in src/_mssql.pyx
+test -f _mssql.c && rm _mssql.c
+$PYTHON setup.py build_ext -I ${PREFIX}/include -L ${PREFIX}/lib
+$PYTHON setup.py install --single-version-externally-managed --record=record.txt

--- a/pymssql/meta.yaml
+++ b/pymssql/meta.yaml
@@ -1,0 +1,50 @@
+{% set name = 'pymssql' %}
+{% set version = '2.1.3' %}
+{% set tag = 'v' + version %}
+{% set number = '0' %}
+
+# Original recipe can be found here:
+#       https://github.com/conda/conda-recipes
+
+about:
+  home: http://pymssql.org
+  license: GNU Library or Lesser General Public License (LGPL)
+  summary: 'DB-API interface to Microsoft SQL Server for Python. (new Cython-based version)'
+  license_family: LGPL
+  doc_url: http://www.pymssql.org/en/stable/
+  dev_url: https://github.com/pymssql/pymssql
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+build:
+  number: {{ number }}
+
+requirements:
+  build:
+    - openssl 1.0.*     # [win]
+    - python
+    - cython
+    - setuptools
+    - libiconv          # [win]
+    - freetds >=1.00.9
+
+  run:
+    - python
+    - freetds >=1.00.9
+
+source:
+  git_tag: {{ tag }}
+  git_url: https://github.com/{{ name }}/{{ name }}.git
+
+  patches:
+   - 0001-Drop-usage-of-DBVERSION_80-symbol-d90c9b.patch
+   - 0002-Change-setup_requires-setuptools_git-to-setuptools.patch
+   - 0003-Use-libsybdb-not-db-lib-since-I-renamed-it.patch
+   - 0004-Win32-link-to-openssl.patch
+
+
+test:
+  imports:
+    - pymssql


### PR DESCRIPTION
**Reason we are building it:** 
- Continuum has abandoned this recipe upstream
- JWST pipeline requires it

**Notes:**
I yanked this from `conda/conda-recipes` and modified it. The patches have been adjusted to work with 2.1.3, because someone injected patches against an unreleased version of `pymssql` using a different directory structure. 🎱 

