### PR TITLE
JWST: Add matplotlib as build dependency

### DIFF
--- a/jwst/meta.yaml
+++ b/jwst/meta.yaml
@@ -20,6 +20,7 @@ package:
 requirements:
     build:
     - astropy
+    - matplotlib
     - namedlist
     - numpy >=1.7*
     - setuptools


### PR DESCRIPTION
Recently added to source base; wasn't informed.