### PR TITLE
pyobjc: Enforce rpath padding

### DIFF
--- a/pyobjc-core/build.sh
+++ b/pyobjc-core/build.sh
@@ -1,2 +1,3 @@
 cd pyobjc-core
+export CFLAGS="$CFLAGS -headerpad_max_install_names"
 python setup.py install

--- a/pyobjc-framework-cocoa/build.sh
+++ b/pyobjc-framework-cocoa/build.sh
@@ -1,2 +1,3 @@
 cd pyobjc-framework-Cocoa
+export CFLAGS="$CFLAGS -headerpad_max_install_names"
 python setup.py install

--- a/pyobjc-framework-quartz/build.sh
+++ b/pyobjc-framework-quartz/build.sh
@@ -1,2 +1,3 @@
 cd pyobjc-framework-Quartz
+export CFLAGS="$CFLAGS -headerpad_max_install_names"
 python setup.py install


### PR DESCRIPTION
`conda-build` fails to adjust RPATHs unless `-headerpad_max_install_names` is enabled.