### PR TITLE
hstcal: [Darwin] Force 64-bit linking

### DIFF
--- a/hstcal/build.sh
+++ b/hstcal/build.sh
@@ -1,5 +1,9 @@
 if [[ `uname` == Darwin ]]; then
     export CC=`which gcc`
+    if [[ `uname -m` == x86_64 ]]; then
+        export CFLAGS="$CFLAGS -m64"
+        export LDFLAGS="$LDFLAGS -m64"
+    fi
 fi
 
 ./waf configure --prefix=$PREFIX --release-with-symbols


### PR DESCRIPTION
Trying to avoid hundreds of thousands of:
```
error: register %rXX is only available in 64-bit mode
```