### PR TITLE
[py27 fix] Force shared library discovery.

### DIFF
--- a/dbus-python/build.sh
+++ b/dbus-python/build.sh
@@ -1,3 +1,6 @@
+export CFLAGS="-I$PREFIX/include"
+export LDFLAGS="-L$PREFIX/lib"
+
 ./configure --prefix=$PREFIX
 make
 make install


### PR DESCRIPTION
Failed to find `python2.7.so` during compilation of `dbus-python`. Setting C/LD flags corrects the issue. This did not happen while building against Python 3.