### PR TITLE
[astropy] Python 2.7 support dropped upstream. Skipping.

### DIFF
--- a/astropy/meta.yaml
+++ b/astropy/meta.yaml
@@ -8,6 +8,7 @@ about:
     summary: Astropy is a package intended to contain much of the core functionality and some common tools needed for performing astronomy and astrophysics with Python.
 
 build:
+    skip: True [py27]
     number: {{ number }}
 
 package:


### PR DESCRIPTION
Prevents nonsensical Jenkins builds.