### PR TITLE
sextractor: of course the md5 hash changed

### DIFF
--- a/sextractor/meta.yaml
+++ b/sextractor/meta.yaml
@@ -36,7 +36,7 @@ source:
 
     fn: {{ name }}-{{ version }}.tar.gz
     url: https://github.com/astromatic/sextractor/archive/{{ version }}.tar.gz
-    md5: 2115556b5d30571306608b7c023a318f
+    md5: 8b5d957c80d93396503a8bf6698f000a
 
 test:
   commands:


### PR DESCRIPTION
Didn't notice due to cached tarball.
`conda-build` package downloading security is tops.
  