### PR TITLE
Conda's resolver cannot see glueviz >0.8 as latest package

### DIFF
--- a/glueviz/meta.yaml
+++ b/glueviz/meta.yaml
@@ -4,7 +4,7 @@
 
 {% set name = 'glueviz' %}
 {% set version = '0.12.0' %}
-{% set number = '1' %}
+{% set number = '2' %}
 
 package:
   name: {{ name }}
@@ -20,6 +20,11 @@ build:
   script: python setup.py install --single-version-externally-managed --record record.txt
 
 requirements:
+  build:
+    # Conda-build is not smart enough to use 'python' on its own.
+    # DO NOT REMOVE THIS LINE:
+    - python {{ python }}
+
   run:
     - glue-core >=0.12
     - glue-vispy-viewers >=0.9


### PR DESCRIPTION
* Override this behavior by "building" with Python. Dumb but effective.
* Warnings added to prevent this situtation from coming up once again.
  
Rationale:

1. Two packages exist: 0.8.2_py{35,36} and 0.12.0-1
2. `conda install glueviz` finds 0.8.2 because it has py{35,36} in the package name
3. `conda install "glueviz>0.8.2"` installs 0.12.0 because 0.8.2 is no longer considered in the pool of resolved packages
4. Adding `build: - python {{ python }}` and `run: - python` forces `conda-build` to generate a py{VER} package. 