### PR TITLE
stsci.tools: remove circular dependency on stwcs

### DIFF
--- a/stsci.tools/meta.yaml
+++ b/stsci.tools/meta.yaml
@@ -31,7 +31,6 @@ requirements:
     - astropy
     - nose      # .tester
     - pytest    # .tester
-    - stwcs     # .fileutils
     - numpy
     - python
 


### PR DESCRIPTION
* `stwcs` depends on `stsci.tools`
* `stsci.tools` does depend on `stwcs`, but oh well.