### PR TITLE
Optional dependencies are no longer optional. Do not revert.

### DIFF
--- a/acstools/meta.yaml
+++ b/acstools/meta.yaml
@@ -3,7 +3,7 @@
 {% if version[0] == 'v' %}
 {%   set version = version[1:] %}
 {% endif %}
-{% set number = '2' %}
+{% set number = '3' %}
 
 about:
     home: https://github.com/spacetelescope/{{ name }}
@@ -25,6 +25,9 @@ requirements:
 
     run:
     - astropy >=1.1
+    - scikit-image
+    - stsci.tools
+    - matplotlib
     - numpy
     - python
 


### PR DESCRIPTION
Fixes regression tests failing due to missing "optional" dependencies.