### PR TITLE
jwst: Add missing stwcs dependency

### DIFF
--- a/jwst/meta.yaml
+++ b/jwst/meta.yaml
@@ -50,6 +50,7 @@ requirements:
     - stsci.sphere
     - stsci.stimage
     - stsci.tools
+    - stwcs
     - verhawk
     - numpy
     - python


### PR DESCRIPTION
Fixes

```
EXCEPTION
Type: ImportError
Message: No module named 'stwcs'
```