### PR TITLE
Quick fix: add docopt run dependency to specviz recipe

### DIFF
--- a/specviz/meta.yaml
+++ b/specviz/meta.yaml
@@ -3,7 +3,7 @@
 {% if version[0] == 'v' %}
 {%   set version = version[1:] %}
 {% endif %}
-{% set number = '0' %}
+{% set number = '1' %}
 
 about:
   home: https://github.com/spacetelescope/specviz

--- a/specviz/meta.yaml
+++ b/specviz/meta.yaml
@@ -39,6 +39,7 @@ requirements:
   run:
     - astropy
     - cython
+    - docopt
     - specutils
     - py-expression-eval
     - pyyaml


### PR DESCRIPTION
Sorry @jhunkeler. This one fell through the cracks.