### PR TITLE
[mos/spec]viz: Drop specutils 0.2.2 version pinning in setup

### DIFF
--- a/mosviz/build.sh
+++ b/mosviz/build.sh
@@ -1,3 +1,6 @@
+sed 's|specutils==0.2.2|specutils|' < setup.cfg > setup.cfg.new
+cp setup.cfg.new setup.cfg
+
 # Remove reference to glueviz from setup script, since this breaks the build
 # as there is no file containing 'glueviz' produced for that package since
 # glueviz has become a metapackage.

--- a/specviz/build.sh
+++ b/specviz/build.sh
@@ -1,1 +1,4 @@
+sed 's|specutils==0.2.2|specutils|' < setup.cfg > setup.cfg.new
+cp setup.cfg.new setup.cfg
+
 $PYTHON setup.py install


### PR DESCRIPTION
Allows packages to build against development version of specutils.

reason: specutils' internal version is 0.1.dev, and the package requires 0.2.2 (or something equivalent on master)