### PR TITLE
stsci.tools: Remove d2to1 and stsci.distutils dependencies

### DIFF
--- a/stsci.tools/bld.bat
+++ b/stsci.tools/bld.bat
@@ -1,3 +1,1 @@
-
-
 %PYTHON% setup.py install

--- a/stsci.tools/build.sh
+++ b/stsci.tools/build.sh
@@ -1,2 +1,1 @@
-
 $PYTHON setup.py install

--- a/stsci.tools/meta.yaml
+++ b/stsci.tools/meta.yaml
@@ -3,7 +3,7 @@
 {% if version[0] == 'v' %}
 {%   set version = version[1:] %}
 {% endif %}
-{% set number = '5' %}
+{% set number = '0' %}
 
 about:
     home: https://github.com/spacetelescope/{{ name }}
@@ -20,17 +20,14 @@ package:
 
 requirements:
     build:
-    - d2to1
-    - stsci.distutils
     - astropy
+    - pytest-runner
     - setuptools
     - numpy {{ numpy }}
     - python {{ python }}
 
     run:
     - astropy
-    - nose      # .tester
-    - pytest    # .tester
     - numpy
     - python
 


### PR DESCRIPTION
* Also removes `nose` as a run-time dependency and replaces it with `pytest-runner` at compile-time.