### PR TITLE
Truncate READMEs to avoid unicode errors

### DIFF
--- a/fast-histogram/build.sh
+++ b/fast-histogram/build.sh
@@ -1,5 +1,2 @@
-# conda-build does not guarantee LANG will be defined.
-# This avoids a UnicodeDecodeError while ingesting README.rst during setup
-export LANG=UTF-8
-
+echo Nope > README.rst
 $PYTHON setup.py install

--- a/mpl-scatter-density/build.sh
+++ b/mpl-scatter-density/build.sh
@@ -1,1 +1,2 @@
+echo Nope > README.rst
 $PYTHON setup.py install


### PR DESCRIPTION
Avoid `UnicodeDecodeErrors`
:sleeping: :zap: 