### PR TITLE
cfitsio: curl

### DIFF
--- a/cfitsio/meta.yaml
+++ b/cfitsio/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = 'cfitsio' %}
 {% set version = '3.430' %}
 {% set version_short = '3430' %}
-{% set number = '2' %}
+{% set number = '3' %}
 
 about:
     home: http://heasarc.gsfc.nasa.gov/fitsio/fitsio.html
@@ -17,9 +17,12 @@ package:
 
 requirements:
     build:
-    - gcc [osx]
+      - curl
+      - gcc [osx]
+
     run:
-    - libgcc [osx]
+      - curl
+      - libgcc [osx]
 
 source:
     fn: {{ name }}{{ version_short }}.tar.gz


### PR DESCRIPTION
Allowing `libcfitsio` to link against the system's `libcurl` has undesired results on different OSes. Linking against Conda's `curl` should help, but I can't promise Continuum will not break it at some point.