### PR TITLE
Replace deprecated sphere package in JWST

### DIFF
--- a/jwst/meta.yaml
+++ b/jwst/meta.yaml
@@ -45,9 +45,9 @@ requirements:
     - pymssql [not py36]
     - scipy
     - six
+    - spherical_geometry
     - stsci.image
     - stsci.imagestats
-    - stsci.sphere
     - stsci.stimage
     - stsci.tools
     - stwcs


### PR DESCRIPTION
This PR should only become active **AFTER** [JWST PR #1859](https://github.com/STScI-JWST/jwst/pull/1859) has been merged.