### PR TITLE
jwst: Purge unused dependencies

### DIFF
--- a/jwst/meta.yaml
+++ b/jwst/meta.yaml
@@ -35,7 +35,6 @@ requirements:
     - crds
     - dask
     - drizzle
-    - fitsblender
     - gwcs
     - jsonschema
     - jplephem
@@ -50,7 +49,6 @@ requirements:
     - stsci.imagestats
     - stsci.stimage
     - stsci.tools
-    - stwcs
     - verhawk
     - numpy
     - python


### PR DESCRIPTION
```
jwst$ grep -R import | grep -E 'stwcs|fitsblender'
jwst/assign_wcs/tests/test_nirspec.py:from astropy import wcs as astwcs
#
# i.e. there are no imports of these packages
```