### PR TITLE
Cfitsio disable curl

### DIFF
--- a/cfitsio/0001-cfitsio-autoconf-disable-curl.patch
+++ b/cfitsio/0001-cfitsio-autoconf-disable-curl.patch
@@ -1,0 +1,203 @@
+Only in b/cfitsio: autom4te.cache
+diff --recursive -u -p a/cfitsio/configure b/cfitsio/configure
+--- a/cfitsio/configure	2018-05-09 15:16:00.000000000 -0400
++++ b/cfitsio/configure	2018-08-06 15:42:35.000000000 -0400
+@@ -710,6 +710,7 @@ enable_reentrant
+ enable_sse2
+ enable_ssse3
+ enable_hera
++enable_curl
+ with_bzip2
+ with_gsiftp
+ with_gsiftp_flavour
+@@ -1341,6 +1342,7 @@ Optional Features:
+   --enable-ssse3          Enable use of instructions in the SSSE3 extended
+                           instruction set
+   --enable-hera           Build for HERA (ASD use only)
++  --disable-curl          Disable use of cURL library (HTTPS)
+ 
+ Optional Packages:
+   --with-PACKAGE[=ARG]    use PACKAGE [ARG=yes]
+@@ -2264,6 +2266,13 @@ if test "x$BUILD_HERA" = xyes; then
+ 
+ fi
+ 
++# Check whether --enable-curl was given.
++if test "${enable_curl+set}" = set; then :
++  enableval=$enable_curl;  if test $enableval = yes; then CURL_DISABLED=yes; fi
++
++fi
++
++
+ # Optional support for bzip2 compression:
+ ac_ext=c
+ ac_cpp='$CPP $CPPFLAGS'
+@@ -4780,17 +4789,18 @@ if test "x$CFITSIO_SHLIB" = x; then CFIT
+ 
+ # Curl library (will be pulled in to the shared CFITSIO library):
+ # ---------------------------------------------------------------
+-CURL_LIB=""
+-CURL_INC=""
+-# Use curl-config to get compiler & linker flags, if available.
+-# On Macs, prefer XCode curl-config, and reject MacPorts version
+-# until further notice to prevent build errors:
+-if test "x$EXT" = xdarwin -a -x /usr/bin/curl-config; then
+-  CURLCONFIG="/usr/bin/curl-config"
+-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: checking for curl-config... choosing /usr/bin/curl-config on Mac" >&5
++if test "x$CURL_DISABLED" != x; then
++  CURL_LIB=""
++  CURL_INC=""
++  # Use curl-config to get compiler & linker flags, if available.
++  # On Macs, prefer XCode curl-config, and reject MacPorts version
++  # until further notice to prevent build errors:
++  if test "x$EXT" = xdarwin -a -x /usr/bin/curl-config; then
++    CURLCONFIG="/usr/bin/curl-config"
++    { $as_echo "$as_me:${as_lineno-$LINENO}: result: checking for curl-config... choosing /usr/bin/curl-config on Mac" >&5
+ $as_echo "checking for curl-config... choosing /usr/bin/curl-config on Mac" >&6; }
+-else
+-  # Extract the first word of "curl-config", so it can be a program name with args.
++  else
++    # Extract the first word of "curl-config", so it can be a program name with args.
+ set dummy curl-config; ac_word=$2
+ { $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+ $as_echo_n "checking for $ac_word... " >&6; }
+@@ -4844,30 +4854,34 @@ $as_echo "no" >&6; }
+ fi
+ 
+ 
+-fi
+-if test "x$CURLCONFIG" != x; then
+-  CURL_LIB=`$CURLCONFIG --libs`
+-  CURL_INC=`$CURLCONFIG --cflags`
+-  # Also reject anaconda curl on Macs until further notice:
+-  if test "x$EXT" = xdarwin -a `echo $CURL_LIB $CURL_INC | grep -ci anaconda` -gt 0; then
+-    { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: Rejecting Anaconda curl. Disabling HTTPS support." >&5
++  fi
++  if test "x$CURLCONFIG" != x; then
++    CURL_LIB=`$CURLCONFIG --libs`
++    CURL_INC=`$CURLCONFIG --cflags`
++    # Also reject anaconda curl on Macs until further notice:
++    if test "x$EXT" = xdarwin -a `echo $CURL_LIB $CURL_INC | grep -ci anaconda` -gt 0; then
++      { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: Rejecting Anaconda curl. Disabling HTTPS support." >&5
+ $as_echo "$as_me: WARNING: Rejecting Anaconda curl. Disabling HTTPS support." >&2;}
+-  else
+-    LIBS="$CURL_LIB $LIBS"
+-    if test "x$CURL_INC" != x; then
+-      CFLAGS="$CURL_INC $CFLAGS"
+-    fi
+-    $as_echo "#define CFITSIO_HAVE_CURL 1" >>confdefs.h
++    else
++      LIBS="$CURL_LIB $LIBS"
++      if test "x$CURL_INC" != x; then
++        CFLAGS="$CURL_INC $CFLAGS"
++      fi
++      $as_echo "#define CFITSIO_HAVE_CURL 1" >>confdefs.h
+ 
++    fi
++  # No curl-config:
++  else
++    { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: curl-config not found. Disabling HTTPS support." >&5
++$as_echo "$as_me: WARNING: curl-config not found. Disabling HTTPS support." >&2;}
++  # Incomplete stubs for possible future use:
++  #  AC_CHECK_LIB([curl],[main],[],
++  #       [AC_MSG_WARN(Not building curl support for CFITSIO)])
++  #  AC_CHECK_HEADER(curl.h,[])
+   fi
+-# No curl-config:
+ else
+-  { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: curl-config not found. Disabling HTTPS support." >&5
+-$as_echo "$as_me: WARNING: curl-config not found. Disabling HTTPS support." >&2;}
+-# Incomplete stubs for possible future use:
+-#  AC_CHECK_LIB([curl],[main],[],
+-#       [AC_MSG_WARN(Not building curl support for CFITSIO)])
+-#  AC_CHECK_HEADER(curl.h,[])
++  { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: curl disabled. Disabling HTTPS support." >&5
++$as_echo "$as_me: WARNING: curl disabled. Disabling HTTPS support." >&2;}
+ fi
+ 
+ # GSIFTP flags:
+diff --recursive -u -p a/cfitsio/configure.in b/cfitsio/configure.in
+--- a/cfitsio/configure.in	2018-05-09 15:16:00.000000000 -0400
++++ b/cfitsio/configure.in	2018-08-06 15:42:27.000000000 -0400
+@@ -53,6 +53,12 @@ if test "x$BUILD_HERA" = xyes; then
+   AC_DEFINE(BUILD_HERA)
+ fi
+ 
++AC_ARG_ENABLE(
++  curl,
++  [AS_HELP_STRING([--disable-curl],[Disable use of cURL library (HTTPS)])],
++  [ if test $enableval = yes; then CURL_DISABLED=yes; fi ]
++)
++
+ # Optional support for bzip2 compression:
+ AC_ARG_WITH(
+   bzip2,
+@@ -441,37 +447,41 @@ if test "x$CFITSIO_SHLIB" = x; then CFIT
+ 
+ # Curl library (will be pulled in to the shared CFITSIO library):
+ # ---------------------------------------------------------------
+-CURL_LIB=""
+-CURL_INC=""
+-# Use curl-config to get compiler & linker flags, if available.
+-# On Macs, prefer XCode curl-config, and reject MacPorts version
+-# until further notice to prevent build errors:
+-if test "x$EXT" = xdarwin -a -x /usr/bin/curl-config; then
+-  CURLCONFIG="/usr/bin/curl-config"
+-  AC_MSG_RESULT(checking for curl-config... choosing /usr/bin/curl-config on Mac)
+-else
+-  AC_CHECK_PROG([CURLCONFIG], [curl-config], [curl-config], [], [], [/opt/local/bin/curl-config])
+-fi
+-if test "x$CURLCONFIG" != x; then
+-  CURL_LIB=`$CURLCONFIG --libs`
+-  CURL_INC=`$CURLCONFIG --cflags`
+-  # Also reject anaconda curl on Macs until further notice:
+-  if test "x$EXT" = xdarwin -a `echo $CURL_LIB $CURL_INC | grep -ci anaconda` -gt 0; then
+-    AC_MSG_WARN(Rejecting Anaconda curl. Disabling HTTPS support.)
++if test "x$CURL_DISABLED" != x; then
++  CURL_LIB=""
++  CURL_INC=""
++  # Use curl-config to get compiler & linker flags, if available.
++  # On Macs, prefer XCode curl-config, and reject MacPorts version
++  # until further notice to prevent build errors:
++  if test "x$EXT" = xdarwin -a -x /usr/bin/curl-config; then
++    CURLCONFIG="/usr/bin/curl-config"
++    AC_MSG_RESULT(checking for curl-config... choosing /usr/bin/curl-config on Mac)
+   else
+-    LIBS="$CURL_LIB $LIBS"
+-    if test "x$CURL_INC" != x; then
+-      CFLAGS="$CURL_INC $CFLAGS"
++    AC_CHECK_PROG([CURLCONFIG], [curl-config], [curl-config], [], [], [/opt/local/bin/curl-config])
++  fi
++  if test "x$CURLCONFIG" != x; then
++    CURL_LIB=`$CURLCONFIG --libs`
++    CURL_INC=`$CURLCONFIG --cflags`
++    # Also reject anaconda curl on Macs until further notice:
++    if test "x$EXT" = xdarwin -a `echo $CURL_LIB $CURL_INC | grep -ci anaconda` -gt 0; then
++      AC_MSG_WARN(Rejecting Anaconda curl. Disabling HTTPS support.)
++    else
++      LIBS="$CURL_LIB $LIBS"
++      if test "x$CURL_INC" != x; then
++        CFLAGS="$CURL_INC $CFLAGS"
++      fi
++      AC_DEFINE(CFITSIO_HAVE_CURL)
+     fi
+-    AC_DEFINE(CFITSIO_HAVE_CURL)
++  # No curl-config:
++  else
++    AC_MSG_WARN(curl-config not found. Disabling HTTPS support.)
++  # Incomplete stubs for possible future use:
++  #  AC_CHECK_LIB([curl],[main],[],
++  #       [AC_MSG_WARN(Not building curl support for CFITSIO)])
++  #  AC_CHECK_HEADER(curl.h,[])
+   fi
+-# No curl-config:
+ else
+-  AC_MSG_WARN(curl-config not found. Disabling HTTPS support.)
+-# Incomplete stubs for possible future use:
+-#  AC_CHECK_LIB([curl],[main],[],
+-#       [AC_MSG_WARN(Not building curl support for CFITSIO)])
+-#  AC_CHECK_HEADER(curl.h,[])
++  AC_MSG_WARN(curl disabled. Disabling HTTPS support.)
+ fi
+ 
+ # GSIFTP flags:

--- a/cfitsio/build.sh
+++ b/cfitsio/build.sh
@@ -3,6 +3,6 @@ case "$(uname)" in
         export CFLAGS="$CFLAGS -D_POSIX_C_SOURCE=200112L"
     ;;
 esac
-./configure --prefix=$PREFIX --enable-reentrant
+./configure --prefix=$PREFIX --enable-reentrant --disable-curl
 make shared
 make install

--- a/cfitsio/meta.yaml
+++ b/cfitsio/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = 'cfitsio' %}
 {% set version = '3.440' %}
 {% set version_short = '3440' %}
-{% set number = '4' %}
+{% set number = '5' %}
 
 about:
     home: http://heasarc.gsfc.nasa.gov/fitsio/fitsio.html
@@ -23,6 +23,9 @@ requirements:
       - libgcc >=4.6
 
 source:
+    patches:
+      - 0001-cfitsio-autoconf-disable-curl.patch
+
     fn: {{ name }}{{ version_short }}.tar.gz
     url: http://heasarc.gsfc.nasa.gov/FTP/software/fitsio/c/{{ name }}{{ version_short }}.tar.gz
     #md5: 8c9b3383752f1bd663b936c297f19feb # verification broken in conda-build through 3.7.1

--- a/crds/meta.yaml
+++ b/crds/meta.yaml
@@ -3,7 +3,8 @@
 {% if version[0] == 'v' %}
 {%   set version = version[1:] %}
 {% endif %}
-{% set number = '3' %}
+{% set number = '4' %}
+# number = 4 ; links against cfitsio >= 3.440 (no curl)
 
 about:
     home: http://www.stsci.edu/hst/observatory/crds/

--- a/fitsverify/meta.yaml
+++ b/fitsverify/meta.yaml
@@ -1,10 +1,11 @@
 {% set name = 'fitsverify' %}
 {% set version = '4.18' %}
-{% set number = '5' %}
+{% set number = '6' %}
 # number = 1 ; legacy, links against whatever is provided by available cfitsio package
 # number = 2 ; links against cfitsio < 3.410
 # number = 3 ; links against cfitsio >= 3.410
 # number = 5 ; links against cfitsio >= 3.440
+# number = 6 ; links against cfitsio >= 3.440 (no curl)
 
 about:
     home: http://heasarc.gsfc.nasa.gov/fitsio/fitsio.html

--- a/hstcal/meta.yaml
+++ b/hstcal/meta.yaml
@@ -3,7 +3,8 @@
 {% if version[0] == 'v' %}
 {%   set version = version[1:] %}
 {% endif %}
-{% set number = '5' %}
+{% set number = '6' %}
+# number = 6 ; links against cfitsio >= 3.440 (no curl)
 
 about:
     home: https://github.com/spacetelescope/{{ name }}

--- a/stsci/meta.yaml
+++ b/stsci/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = 'stsci' %}
 {% set version = '0.0.0.dev0' %}
-{% set number = '2' %}
+{% set number = '3' %}
 
 about:
     home: http://stsci.edu


### PR DESCRIPTION
Conda's `curl` is broken and a system-level `libcurl` is not guaranteed to exist.

Here's the compromise:

This patch adds `--disable-curl` to the autoconf script so we can turn it off at will. If we figure out a better way to link against curl in the future, maybe we can re-enable it. Until then anyone using this build will not be able to open SSL encrypted streams via native `cfitsio` calls.

We (STScI) do not use the remote API calls in `cfitsio`. 
Sorry if this is an inconvenience to anyone in the community.

If you *need* HTTPS support feel free to edit `build.sh` locally and remove `--disable-curl` from the configuration line. Then execute `conda build` against this recipe. (We cannot offer support for what comes out the other side should you do this. Your mileage may vary.)

cc @stscicrawford @nden @mdlpstsci @jamienoss