### PR TITLE
specviz: circumvent pyqt5 dependency

### DIFF
--- a/specviz/build.sh
+++ b/specviz/build.sh
@@ -1,4 +1,5 @@
-sed 's|specutils==0.2.2|specutils|' < setup.cfg > setup.cfg.new
-cp setup.cfg.new setup.cfg
+sed -e 's|specutils==0.2.2|specutils|' \
+    -e 's|pyqt5||' < setup.cfg > setup.cfg.new
+cp -a setup.cfg.new setup.cfg
 
 $PYTHON setup.py install

--- a/specviz/meta.yaml
+++ b/specviz/meta.yaml
@@ -3,7 +3,7 @@
 {% if version[0] == 'v' %}
 {%   set version = version[1:] %}
 {% endif %}
-{% set number = '1' %}
+{% set number = '2' %}
 
 about:
   home: https://github.com/spacetelescope/specviz
@@ -27,8 +27,10 @@ requirements:
     - specutils
     - py-expression-eval
     - pyyaml
+    - pyqt >=5.0.0
     - pyqtgraph >=0.9.11
     - qtpy
+    - qtawesome
     - scipy
     - spectral-cube
     - yaml
@@ -43,8 +45,10 @@ requirements:
     - specutils
     - py-expression-eval
     - pyyaml
+    - pyqt >=5.0.0
     - pyqtgraph >=0.9.11
     - qtpy
+    - qtawesome
     - scipy
     - spectral-cube
     - yaml
@@ -55,6 +59,7 @@ test:
   requires:
     - astropy
     - specutils
+
   imports:
     - specviz
 


### PR DESCRIPTION
`(pyqt5 || PyQt5) != pyqt >=5.0.0`

Thanks Conda.