### PR TITLE
Add 3.7 to conda_build_config.yaml

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -1,9 +1,10 @@
 python:
   - 3.5
   - 3.6
+  - 3.7
 
 numpy:
-  - 1.13
+  - 1.14
 
 pin_build_as_run:
   python:


### PR DESCRIPTION
Bumping `numpy` base to match what's available/compatible in the channel (`np11[1,4,5]`). 

---

👦 : Santa, why are you inconsistent with the presents you give to children from year to year?

🎅 : Ho ho ho! Oh child... Wouldn't you like to know!