### PR TITLE
System gcc

### DIFF
--- a/cfitsio/meta.yaml
+++ b/cfitsio/meta.yaml
@@ -17,7 +17,6 @@ package:
 
 requirements:
     build:
-      - gcc >=4.6
 
     run:
       - libgcc >=4.6

--- a/hstcal/meta.yaml
+++ b/hstcal/meta.yaml
@@ -22,7 +22,6 @@ requirements:
     build:
       - cfitsio
       - pkg-config
-      - gcc >=4.7
 
     run:
       - cfitsio


### PR DESCRIPTION
This pull requests should use the system gcc to build CFITSIO and HSTCal.  This should address problems introduced by the current build of the anaconda gcc. 