### PR TITLE
Fix py37 package resolution failures

### DIFF
--- a/stsci-data-analysis/meta.yaml
+++ b/stsci-data-analysis/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = 'stsci-data-analysis' %}
 {% set version = '0.0.0.dev0' %}
-{% set number = '5' %}
+{% set number = '6' %}
 
 about:
     home: http://stsci.edu

--- a/stsci-hst/meta.yaml
+++ b/stsci-hst/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = 'stsci-hst' %}
 {% set version = '0.0.0.dev0' %}
-{% set number = '4' %}
+{% set number = '5' %}
 
 about:
     home: http://www.stsci.edu
@@ -37,11 +37,9 @@ requirements:
       - stsci.imagemanip >=*0.0*
       - stsci.imagestats >=*0.0*
       - stsci.ndimage >=*0.0*
-      - stsci.numdisplay >=*0.0*
       - stsci.sphinxext >=*0.0*
       - stsci.stimage >=*0.0*
       - stsci.skypac >=*0.0*
-      - stsci.sphere >=*0.0*
       - stsci.tools >=*0.0*
       - stwcs >=*0.0*
       - wfpc2tools >=*0.0*

--- a/stsci/meta.yaml
+++ b/stsci/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = 'stsci' %}
 {% set version = '0.0.0.dev0' %}
-{% set number = '5' %}
+{% set number = '6' %}
 
 about:
     home: http://stsci.edu


### PR DESCRIPTION
* Remove totally deprecated dependencies
* Future: If recipe no longer exists... remove from metapackage

Build revision bumped across all metapackages to ensure rebuilds.