### PR TITLE
astropy-healpix: Remove setuptools pin

### DIFF
--- a/astropy-healpix/meta.yaml
+++ b/astropy-healpix/meta.yaml
@@ -21,7 +21,7 @@ requirements:
   build:
     - astropy
     - cython
-    - setuptools <38.5.1
+    - setuptools
     - numpy {{ numpy }}
     - python {{ python }}
 


### PR DESCRIPTION
Cannot build under 3.7 without newer `setuptools`.

- Might affect 3.6 if that pesky `cython` segfault still exists. We'll find out.