### PR TITLE
update ds9 to v8.0

### DIFF
--- a/ds9/meta.yaml
+++ b/ds9/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = 'ds9' %}
-{% set version = '8.0' %}
+{% set version = '8.0.1' %}
 {% set number = '0' %}
 
 about:

--- a/ds9/meta.yaml
+++ b/ds9/meta.yaml
@@ -21,4 +21,4 @@ requirements:
 source:
     fn: {{ name }}.{{ version }}.tar.gz
     url: http://ds9.si.edu/download/source/{{ name }}.{{ version }}.tar.gz
-    md5: 5684be5f6123f3d0426ea3db46466cb4
+    md5: 224924e8aaaceb732cad3bb689afbf57

--- a/ds9/meta.yaml
+++ b/ds9/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = 'ds9' %}
-{% set version = '7.5' %}
-{% set number = '2' %}
+{% set version = '8.0' %}
+{% set number = '0' %}
 
 about:
     home: http://ds9.si.edu/download/source/


### PR DESCRIPTION
Move ds9 version to latest release.

@jhunkeler @rendinam not sure if the md5 hash also needs to be updated. 