### PR TITLE
removed pyyaml from recipe

### DIFF
--- a/hlapipeline/meta.yaml
+++ b/hlapipeline/meta.yaml
@@ -36,7 +36,6 @@ requirements:
     - scipy
     - matplotlib
     - photutils
-    - pyyaml
     - astroquery
     - scipy
     - sphinx


### PR DESCRIPTION
Removing unused pyyaml dependency to fix conda build failures.