### PR TITLE
Pin jsonschema <=2.6

### DIFF
--- a/jwst/meta.yaml
+++ b/jwst/meta.yaml
@@ -26,10 +26,9 @@ requirements:
     - crds
     - drizzle
     - gwcs
-    - jsonschema
+    - jsonschema <=2.6
     - jplephem
     - matplotlib
-    - namedlist
     - photutils
     - pymssql
     - pytest
@@ -38,7 +37,6 @@ requirements:
     - stsci.image
     - stsci.imagestats
     - stsci.stimage
-    - stsci.tools
     - verhawk
     - setuptools
     - numpy {{ numpy }}
@@ -50,10 +48,9 @@ requirements:
     - crds
     - drizzle
     - gwcs
-    - jsonschema
+    - jsonschema <=2.6
     - jplephem
     - matplotlib
-    - namedlist
     - photutils
     - pymssql
     - pytest
@@ -62,7 +59,6 @@ requirements:
     - stsci.image
     - stsci.imagestats
     - stsci.stimage
-    - stsci.tools
     - verhawk
     - numpy
     - python


### PR DESCRIPTION
Conda made a package of `jsonschema 3.0` yesterday and broke the `jwst` package, which really needs `>=2.3,<=2.6` (due to `asdf`):
```
$ firewatch -t 2d | grep jsonschema
2019-03-11T16:32:36 : main/osx-64 : jsonschema-3.0.1-py27_0.tar.bz2         
2019-03-11T16:40:13 : main/osx-64 : jsonschema-3.0.1-py37_0.tar.bz2         
2019-03-11T16:40:45 : main/osx-64 : jsonschema-3.0.1-py36_0.tar.bz2         
```
Also, removing 2 dependencies that are no longer needed - `stsci.tools` and `namedlist`.