### PR TITLE
Remove jwst.steps from import test in jwst recipe

### DIFF
--- a/jwst/meta.yaml
+++ b/jwst/meta.yaml
@@ -73,5 +73,3 @@ source:
 test:
     imports:
     - jwst
-    - jwst.steps
-    # no timeconversion: JPL network is too unstable to obtain *.bsp files.


### PR DESCRIPTION
This submodule import smoke test is now moved to the package unit tests of `jwst` itself, so no need to do it here.  And we would like to remove `steps.py` as it now serves no purpose.

See https://github.com/spacetelescope/jwst/pull/3561